### PR TITLE
Remove 'Organizers Screen' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,1 @@
 # junimo-project
-
-The Orgazniers Screen 


### PR DESCRIPTION
Remove the 'Organizers Screen' section from the README.